### PR TITLE
Use "exec" to start the final executable in multirustproxy

### DIFF
--- a/src/multirustproxy
+++ b/src/multirustproxy
@@ -167,6 +167,4 @@ export MULTIRUST_TOOLCHAIN
 export MULTIRUST_HOME
 export MULTIRUST_ENGAGED
 
-"$sysroot/bin/$rust_cmd" $extra_flags "$@"
-exit_code=$?
-exit $exit_code
+exec "$sysroot/bin/$rust_cmd" $extra_flags "$@"


### PR DESCRIPTION
Use "exec" to avoid a fork, so you don't have to, for example, setup gdb
to follow child processes.
