### PR TITLE
Mentioned ~/.multirust in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ dynamic linking, even though the toolchains live in various places.
 It keeps Cargo's metadata isolated per toolchain via the `CARGO_HOME`
 environment variable.
 
+`multirust` saves settings and toolchains in `~/.multirust`. The directory 
+is initialized when using the `multirust` command to set the default channel,
+or when setting an override or default for first time.
+
 # Can you trust Rust binaries?
 
 Although multirust verifies signatures of its downloads if GPG is

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ dynamic linking, even though the toolchains live in various places.
 It keeps Cargo's metadata isolated per toolchain via the `CARGO_HOME`
 environment variable.
 
-`multirust` saves settings and toolchains in `~/.multirust`. The directory 
-is initialized when using the `multirust` command to set the default channel,
-or when setting an override or default for first time.
+`multirust` saves settings and toolchains per user in `~/.multirust`. 
+The directory is initialized when using the `multirust` command to 
+set the default channel, or when setting an override or updating for first time.
 
 # Can you trust Rust binaries?
 


### PR DESCRIPTION
Added a mention of the ~/.multirust directory to the README.md file. I'm not quite sure of the wording or placement, however this is pertinent information and should best be included in the readme. 
