### PR TITLE
Fix invalid return statement

### DIFF
--- a/src/multirustproxy
+++ b/src/multirustproxy
@@ -104,7 +104,7 @@ toolchain="$(call_multirust ctl override-toolchain)"
 if [ $? != 0 ]; then
     # If this fails, multirust will display an error,
     # which looks better than multirustproxy doing so.
-    return 1
+    exit 1
 fi
 assert_nz "$toolchain" "toolchain is empty"
 


### PR DESCRIPTION
Avoid the shell yelling when no toolchain installed yet:

```
pnovotnik@xitep ~> rustc --version
multirust: no default toolchain configured
/home/pnovotnik/Library/bin/rustc: line 107: return: can only `return' from a function or sourced script
multirustproxy: assert_nz toolchain is empty
```
