### PR TITLE
Handle spaces in (ancestor) directories more robustly

### DIFF
--- a/src/multirust
+++ b/src/multirust
@@ -999,7 +999,7 @@ find_override() {
 	    fi
 	done < "$override_db"
 
-	local _dir="$(dirname $_dir)"
+	local _dir="$(dirname "$_dir")"
     done
 
     return 1


### PR DESCRIPTION
- BSD `dirname` likes to print a usage message if it gets more than one
  argument, which I think is standard on OS X.
- This causes `multirust` to get stuck in a loop because it can't
  traverse the cwd up to the root
- Quoting the appropriate variable properly escapes spaces
