### PR TITLE
open_documentation: add open as a potential target

### DIFF
--- a/src/multirust
+++ b/src/multirust
@@ -1229,12 +1229,14 @@ open_documentation() {
     local _cmd
     if has_cmd "xdg-open"; then
 	_cmd="xdg-open"
+    elif has_cmd "open"; then
+	_cmd="open"
     elif has_cmd "firefox"; then
 	_cmd="firefox"
     elif has_cmd "chromium"; then
 	_cmd="chromium"
     else
-	err "Need xdg-open, firefox, or chromium"
+	err "Need xdg-open, open, firefox, or chromium"
     fi
     find_override_toolchain_or_default
     local _toolchain="$RETVAL"


### PR DESCRIPTION
Adds `open` as a potential target for `open_documentation`. Primarily for OS X but I'm [led to believe](http://linux.die.net/man/1/open) this might be handy on some Linux distributions.
