### PR TITLE
Add default-toolchain to ctl

### DIFF
--- a/src/multirust
+++ b/src/multirust
@@ -489,6 +489,10 @@ handle_command_line_args() {
 		    ctl_print_override_toolchain_or_default
 		    ;;
 
+		default-toolchain)
+		    ctl_print_default_toolchain
+		    ;;
+
 		toolchain-sysroot)
 		    if [ -z "${3-}" ]; then
 			err "unspecified toolchain"
@@ -1342,6 +1346,15 @@ ctl_print_override_toolchain_or_default() {
 	exit 1
     fi
     echo "$RETVAL"
+}
+
+ctl_print_default_toolchain() {
+    find_default
+    if [ $? != 0 ]; then
+	say_err "no default toolchain configured"
+	exit 1
+    fi
+    echo "$RETVAL_TOOLCHAIN"
 }
 
 ctl_print_toolchain_sysroot() {

--- a/test.sh
+++ b/test.sh
@@ -1047,6 +1047,24 @@ remove_toolchain_then_add_again() {
 }
 runtest remove_toolchain_then_add_again
 
+ctl_default_toolchain_no_default() {
+    expect_output_fail "no default toolchain configured" multirust ctl default-toolchain
+}
+runtest ctl_default_toolchain_no_default
+
+ctl_default_toolchain_with_default_no_override() {
+    try multirust default beta
+    expect_output_ok "beta" multirust ctl default-toolchain
+}
+runtest ctl_default_toolchain_with_default_no_override
+
+ctl_default_toolchain_with_default_and_override() {
+    try multirust default beta
+    try multirust override nightly
+    expect_output_ok "beta" multirust ctl default-toolchain
+}
+runtest ctl_default_toolchain_with_default_and_override
+
 echo
 echo "SUCCESS!"
 echo


### PR DESCRIPTION
This is mainly done with the purpose to be used for shell prompts and get around needing environment variables ( #75 )

As a proof of concept I have edited a prompt to use [this method](https://github.com/zyphrus/bullet-train-oh-my-zsh-theme/blob/master/bullet-train.zsh-theme#L393)
