### PR TITLE
Stable is the new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -sf https://raw.githubusercontent.com/brson/multirust/master/blastoff.sh | 
 ```
 
 This will build and install multirust, possibly prompting you for your
-password via `sudo`. It will then download and install the nightly
+password via `sudo`. It will then download and install the stable
 toolchain, configuring it as the default when executing `rustc`,
 `rustdoc`, and `cargo`.
 


### PR DESCRIPTION
As of 95fe46e249399e12129e48804705a968513e66fe, blastoff.sh defaults to an installation of the stable toolchain. This just updates the README to reflect that change.
