### PR TITLE
Add first run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Run `./build.sh && ./install.sh --help` to see a list of available options.
 
 # Usage
 
+To install rust, run `multirust update <toolchain>`. See `multirust help update` for
+details and to configure what this will install.
+
 Overriding the compiler in specific directories:
 
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Run `./build.sh && ./install.sh --help` to see a list of available options.
 
 # Usage
 
-To install rust, run `multirust update <toolchain>`. See `multirust help update` for
+To install Rust, run `multirust update <toolchain>`. See `multirust help update` for
 details and to configure what this will install.
 
 Overriding the compiler in specific directories:


### PR DESCRIPTION
I didn't use the `blastoff.sh` script to install multirust and was very confused how to take the first step. I would love to see something like this in the instructions to get someone set up with the bare minimum to use multirust.
