### PR TITLE
Fix: Suppress unwanted output on stderr

### DIFF
--- a/src/multirust
+++ b/src/multirust
@@ -1030,7 +1030,7 @@ find_override() {
             # This conversion is *also* done when adding the override directory to
             # the override DB. It is only done here to be compatible with older
             # multirust installations from before this bug was fixed.
-            local _ovrdir="$(cd "$_ovrdir" && pwd -P)"
+            local _ovrdir="$(cd "$_ovrdir" 2>/dev/null && pwd -P)"
             # NB: The above may fail, e.g. if _ovrdir no longer exists.
             # This is fine since it will just make the next comparision fail as well.
 


### PR DESCRIPTION
Like it already said in the comments: The `cd` call might fail and thats ok, since it's ignored. However, the command `cd` sometimes prints stuff to stderr, for example if the current user lacks permission to read the directory. This is pretty annoying in an environment where the .multirust config folder (hence the overrides) is shared between multiple users. So since we want to ignore every error from `cd` anyway, I piped the stderr to /dev/null to silence the command.

(If anything is wrong with my PR, let me know)
