### PR TITLE
Allow for explicit naming of overrides to remove

### DIFF
--- a/src/multirust
+++ b/src/multirust
@@ -468,12 +468,12 @@ handle_command_line_args() {
         list-overrides) list_overrides;;
         list-toolchains) list_toolchains;;
         remove-override) 
-		if [ $# -gt 1 ]; then 
-			remove_override $2
-		else 
-	       		remove_override "$(pwd -P)"
-		fi
-	;;
+            if [ $# -gt 1 ]; then 
+                remove_override $2
+            else 
+                remove_override "$(pwd -P)"
+            fi
+        ;;
 
         remove-toolchain)
             if [ -z "${2-}" ]; then

--- a/src/multirust
+++ b/src/multirust
@@ -467,7 +467,13 @@ handle_command_line_args() {
         show-override) show_override;;
         list-overrides) list_overrides;;
         list-toolchains) list_toolchains;;
-        remove-override) remove_override;;
+        remove-override) 
+		if [ $# -gt 1 ]; then 
+			remove_override $2
+		else 
+	       		remove_override "$(pwd -P)"
+		fi
+	;;
 
         remove-toolchain)
             if [ -z "${2-}" ]; then
@@ -1113,7 +1119,7 @@ set_override() {
 }
 
 remove_override() {
-    local _override_dir="$(pwd -P)"
+    local _override_dir=$@
     assert_nz "$_override_dir" "empty pwd?"
 
     # Escape forward-slashes
@@ -1133,7 +1139,7 @@ remove_override() {
         fi
     fi
     if [ $_have_override = false ]; then
-        say "no override for current directory '$_override_dir'"
+        say "no override for directory '$_override_dir'"
         return
     fi
 

--- a/src/multirust
+++ b/src/multirust
@@ -13,7 +13,7 @@
 #     show-default     Show information about the current default
 #     list-overrides   List all overrides
 #     list-toolchains  List all installed toolchains
-#     remove-override  Remove the current override
+#     remove-override  Remove an override, for current directory unless specified
 #     remove-toolchain Uninstall a toolchain
 #     run              Run a command in an environment configured for a toolchain
 #     delete-data      Delete all user metadata, including installed toolchains
@@ -175,9 +175,10 @@
 
 # <help-remove-override>
 #
-# Removes the override for the current directory.
+# Removes the override for the current directory, or the named override
+# if one is provided.
 #
-# Usage: multirust remove-override
+# Usage: multirust remove-override [override]
 #
 # </help-remove-override>
 
@@ -468,10 +469,10 @@ handle_command_line_args() {
         list-overrides) list_overrides;;
         list-toolchains) list_toolchains;;
         remove-override) 
-            if [ $# -gt 1 ]; then 
-                remove_override $2
-            else 
+            if [ -z "${2-}" ]; then 
                 remove_override "$(pwd -P)"
+            else 
+                remove_override $2
             fi
         ;;
 
@@ -1119,7 +1120,7 @@ set_override() {
 }
 
 remove_override() {
-    local _override_dir=$@
+    local _override_dir="$1"
     assert_nz "$_override_dir" "empty pwd?"
 
     # Escape forward-slashes


### PR DESCRIPTION
If there is not a named override, use current directory.
If there is, use it instead.

Thought it would be useful when I noticed that, after removing a directory that had been overridden, executing cargo would result in a multirust error, because the directory did not exist. Had to recreate the directory, remove the override, and then delete the directory again. Thought this would be easier.
