### PR TITLE
Fuzzy command matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ build` will run the beta cargo, regardless of the current
 override. This can also be used to e.g. open a beta shell like
 `multirust run beta bash`.
 
+Commands can be abbreviated by using a prefix of the intended command,
+for example `multirust ru` (`run`) or `multirust s-o` (`show-override`).
+In the case of an ambiguous prefix, it picks the first match using the
+order of commands shown in `multirust help`.
+
 # Toolchain specification
 
 `multirust` supports several ways to indicate the toolchain: 'stable',

--- a/src/multirust
+++ b/src/multirust
@@ -409,7 +409,7 @@ Mve696B5tlHyc1KxjHR6w9GRsh4=
 
     for opt in "$@"; do
         case "$opt" in
-            --verbose)
+            -v | --verbose)
                 flag_verbose=true
             ;;
 
@@ -548,7 +548,7 @@ handle_command_line_args() {
             esac
         ;;
 
-        --version)
+        -V | --version)
             echo "multirust $version ($commit_version)"
             exit 0
         ;;

--- a/src/multirust
+++ b/src/multirust
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # <help>
 #
@@ -431,6 +431,62 @@ Mve696B5tlHyc1KxjHR6w9GRsh4=
 
 handle_command_line_args() {
     local _cmd_arg="${1-}"
+
+    # begin fuzzy matching
+
+    # list of all commands
+    local _cmds=(
+        update
+        default
+        override
+        show-default
+        show-override
+        list-overrides
+        list-toolchains
+        remove-override
+        remove-toolchain
+        run
+        upgrade-data
+        delete-data
+        which
+        ctl
+        doc
+        help
+    )
+
+    for _cmd in "${_cmds[@]}"; do
+        if [[ $_cmd =~ - && $_cmd_arg =~ - ]]; then
+            # split on - then check each part for a prefix match
+            local _cmd_parts=(${_cmd//-/ })
+            local _arg_parts=(${_cmd_arg//-/ })
+            local i
+            if [[ ${#_cmd_parts[@]} == ${#_arg_parts[@]} ]]; then
+                local sofar=0
+                for i in ${!_cmd_parts[@]}; do
+                    if [[ ${_cmd_parts[$i]} == ${_arg_parts[$i]} ]]; then
+                        sofar=$(( $sofar + 1 ))
+                        continue
+                    fi
+                    if [[ $(expr ${_cmd_parts[$i]} : ${_arg_parts[$i]}) > 0 ]]; then
+                        sofar=$(( $sofar + 1 ))
+                        continue
+                    fi
+                    break
+                done
+                if [[ $sofar == ${#_cmd_parts[@]} ]]; then
+                    _cmd_arg=$_cmd
+                    break
+                fi
+            fi
+        else
+            # just check for a prefix match
+            if [[ $(expr $_cmd : $_cmd_arg) > 0 ]]; then
+                _cmd_arg=$_cmd
+                break
+            fi
+        fi
+    done
+    # end fuzzy matching (if there was a match, $_cmd_arg has been replaced)
 
     # Make sure we're working with an up-to-date metadata format
     case "$_cmd_arg" in


### PR DESCRIPTION
Not sure if you'll want to accept this patch. I aliased multirust to "mr" for less typing, and then realized I wanted to be able to type "mr u" or "mr sh-def", etc. So I wrote some fuzzy matching code to do that (I also added -v (--verbose) and -V (--version) to match rustc). The fuzzy matching only works in bash, but it checks for bash before trying.
