### PR TITLE
Modify the PATH in multirustproxy for Windows support

### DIFF
--- a/src/multirustproxy
+++ b/src/multirustproxy
@@ -124,6 +124,7 @@ lib_path="$sysroot/lib"
 # Find the libraries we need
 LD_LIBRARY_PATH="$lib_path:${LD_LIBRARY_PATH-}"
 DYLD_LIBRARY_PATH="$lib_path:${DYLD_LIBRARY_PATH-}"
+PATH="${PATH-}:$sysroot/bin"
 
 # Isolate cargo
 CARGO_HOME=${CARGO_HOME-"$sysroot/cargo"}
@@ -141,5 +142,6 @@ export DYLD_LIBRARY_PATH
 export CARGO_HOME
 export MULTIRUST_TOOLCHAIN
 export MULTIRUST_HOME
+export PATH
 
 exec "$sysroot/bin/$rust_cmd" $extra_flags "$@"


### PR DESCRIPTION
On Windows, shared libraries (DLLs) are searched for in the `PATH`, so it should be pointed to the `$sysroot/bin` directory where the DLLs are in the Windows Rust packages.

`rustup` is also changed to point to a version which includes https://github.com/rust-lang/rustup/pull/29. This is sufficient, in my testing, to make multirust at least minimally functional under MSYS.

This has the side effect of causing `cargo` calls to `rustc` and `rustdoc` to just call the toolchain binaries directly rather than go through the proxies again. This shouldn't cause any problems, but I currently don't have a Linux machine to test on. If this behavior isn't desired, a check to only update `PATH` on windows could be added.
