### PR TITLE
When fuzzy matching don't prefix-check if no arguments

### DIFF
--- a/src/multirust
+++ b/src/multirust
@@ -480,7 +480,7 @@ handle_command_line_args() {
             fi
         else
             # just check for a prefix match
-            if [[ $(expr $_cmd : $_cmd_arg) > 0 ]]; then
+            if [[ $_cmd_arg != '' && $(expr $_cmd : $_cmd_arg) > 0 ]]; then
                 _cmd_arg=$_cmd
                 break
             fi


### PR DESCRIPTION
- This avoids the `expr` utility displaying a `syntax error` when
  `multirust` is invoked with no arguments
