### PR TITLE
"multirust help unknown-topic" triggers "multirust help" at the end.

### DIFF
--- a/src/multirust
+++ b/src/multirust
@@ -600,6 +600,10 @@ handle_command_line_args() {
                 ;;
                 *)
                     display_topic help-"${2-}"
+                    if [ $? != 0 ]; then
+                        display_topic help
+                        exit 1
+                    fi
                 ;;
             esac
         ;;
@@ -1539,10 +1543,13 @@ display_topic() {
     local _multirust_src="$cmd_dirname/multirust"
 
     extract_topic_from_source "$_multirust_src" "$_topic"
+    ret=$?
 
-    if [ $? != 0 ]; then
-        err "unrecognized topic '$_topic'"
+    if [ $ret != 0 ]; then
+        say_err "unrecognized topic '$_topic'"
+        return $ret
     fi
+    return 0
 }
 
 extract_topic_from_source() {


### PR DESCRIPTION
Before:

```
$ multirust help xyzzy

multirust: unrecognized topic 'help-xyzzy'
```

After:

```
$ /tmp/mr0/bin/multirust help xyzzy

multirust: unrecognized topic 'help-xyzzy'
Usage: multirust <command> [--verbose] [--version]

Commands:

    default          Set the default toolchain
    override         Set the toolchain override for the current directory tree
    update           Install or update a given toolchain
    show-override    Show information about the current override
    show-default     Show information about the current default
    list-overrides   List all overrides
    list-toolchains  List all installed toolchains
    remove-override  Remove an override, for current directory unless specified
    remove-toolchain Uninstall a toolchain
    run              Run a command in an environment configured for a toolchain
    delete-data      Delete all user metadata, including installed toolchains
    upgrade-data     Upgrade the ~/.multirust directory from previous versions
    doc              Open the documentation for the currently active toolchain
    which            Report location of the currently active Rust tool.
    help             Show help for this command or subcommands

Use `multirust help <command>` for detailed help.
```
