### PR TITLE
help: Add list of typical toolchain names

### DIFF
--- a/src/multirust
+++ b/src/multirust
@@ -8,7 +8,7 @@
 #
 #     default          Set the default toolchain
 #     override         Set the toolchain override for the current directory tree
-#     update           Install or update a given toolchain
+#     update           Install or update a given toolchain (for example, "stable", "beta", "nightly")
 #     show-override    Show information about the current override
 #     show-default     Show information about the current default
 #     list-overrides   List all overrides


### PR DESCRIPTION
I didn't immediately realized that "toolchain" is that stability edition.

I though I need to specify something like `i686-unknown-linux-gnu`
and there was no command to list all possible toolchains.
