### PR TITLE
sync get_architecture() function

### DIFF
--- a/blastoff.sh
+++ b/blastoff.sh
@@ -102,8 +102,13 @@ get_architecture() {
             local _cputype=arm
             ;;
 
-        armv7l)
+        armv6l)
             local _cputype=arm
+            local _ostype="${_ostype}eabihf"
+            ;;
+
+        armv7l)
+            local _cputype=armv7
             local _ostype="${_ostype}eabihf"
             ;;
 

--- a/quick-install.sh
+++ b/quick-install.sh
@@ -102,8 +102,13 @@ get_architecture() {
             local _cputype=arm
             ;;
 
-        armv7l)
+        armv6l)
             local _cputype=arm
+            local _ostype="${_ostype}eabihf"
+            ;;
+
+        armv7l)
+            local _cputype=armv7
             local _ostype="${_ostype}eabihf"
             ;;
 

--- a/test-v1.sh
+++ b/test-v1.sh
@@ -286,8 +286,13 @@ get_architecture() {
             local _cputype=arm
         ;;
 
-        armv7l)
+        armv6l)
             local _cputype=arm
+            local _ostype="${_ostype}eabihf"
+        ;;
+
+        armv7l)
+            local _cputype=armv7
             local _ostype="${_ostype}eabihf"
         ;;
 

--- a/test-v2.sh
+++ b/test-v2.sh
@@ -289,8 +289,13 @@ get_architecture() {
             local _cputype=arm
         ;;
 
-        armv7l)
+        armv6l)
             local _cputype=arm
+            local _ostype="${_ostype}eabihf"
+        ;;
+
+        armv7l)
+            local _cputype=armv7
             local _ostype="${_ostype}eabihf"
         ;;
 


### PR DESCRIPTION
to match the change in rust-lang/rustup#48

I don't know if I need to update the rustup submodule as well?

cc @alexcrichton @brson 
